### PR TITLE
Properly pass stdio handles to child process

### DIFF
--- a/shim.cpp
+++ b/shim.cpp
@@ -124,6 +124,8 @@ std::tuple<std::unique_handle, std::unique_handle> MakeProcess(const std::wstrin
     std::unique_handle threadHandle;
     std::unique_handle processHandle;
 
+    GetStartupInfoW(&si);
+
     if (CreateProcessW(nullptr, cmd.data(), nullptr, nullptr, TRUE, CREATE_SUSPENDED, nullptr, nullptr, &si, &pi))
     {
         threadHandle.reset(pi.hThread);


### PR DESCRIPTION
See ScoopInstaller/Scoop#4849 and restic/restic#3681

When a process (A) spawns a process (B) with `DETACHED_PROCESS` and communicate with it via stdio redirections, process B isn't attached to a console, but its STD_XXX_HANDLEs are still valid (set by process A). However, with shim in the middle, such communication is broken, because for unknown reason the stdio handles are not properly passed down.

This PR fixes such problem by manually passing down handles via `STARTUPINFOW`. However during my test, although restic/rclone succeeded to work, a blank console window still popped up. It may be suppressed via `CREATE_NO_WINDOW` creation flag, but I don't know if it would break other things..

Code I used to test:

Code for process A (golang, expecting the child/shim executable name = testtarget):
```golang
package main

import "fmt"
import "os"
import "os/exec"
import "bufio"
import "syscall"
import "golang.org/x/sys/windows"

func main() {
	cmd := exec.Command("testtarget")

	r, stdin, err := os.Pipe()
	if err != nil {
		fmt.Println("Failed to open read pipe", err)
	}

	stdout, w, err := os.Pipe()
	if err != nil {
		// close first pipe and ignore subsequent errors
		_ = r.Close()
		_ = stdin.Close()
		fmt.Println("Failed to open write pipe", err)
	}
	cmd.Stdin = r
	cmd.Stdout = w

	cmd.SysProcAttr = &syscall.SysProcAttr{}
	cmd.SysProcAttr.CreationFlags = windows.DETACHED_PROCESS
	err = cmd.Start()

	if err != nil {
		fmt.Println("Failed to start proc. ", err)
	}

	stdoutBuf := bufio.NewReader(stdout)
	stdinBuf := bufio.NewWriter(stdin)
	for {
		line, err := stdoutBuf.ReadString('\n')
		if err != nil {
			break
		}

		fmt.Println("from subproc: ", line)
		stdinBuf.WriteString("response\n")
		stdinBuf.Flush()
	}

	cmd.Wait()
	fmt.Println("exitcode: ", cmd.ProcessState.ExitCode());
	r.Close()
	w.Close()
	stdin.Close()
	stdout.Close()
}

```

Code for process B (C++):
```cpp
#include <Windows.h>
#include <sstream>
#include <iomanip>

int main() {
    auto hin = GetStdHandle(STD_INPUT_HANDLE);
    auto hout = GetStdHandle(STD_OUTPUT_HANDLE);

    DWORD tlen = 0;
    DWORD ilen = 100;
    char inbuf[100];

    auto sstream = std::ostringstream();
    sstream<<std::hex<<(uintptr_t)(hin)<<std::endl;
    auto str = sstream.str();

    if (!WriteFile(hout, str.c_str(), str.size(), &tlen, nullptr))
        return -1;


    if (!ReadFile(hin, inbuf, ilen, &tlen, nullptr))
        return -1;

    sstream = std::ostringstream();
    sstream<<std::hex<<(uintptr_t)(hout)<<std::endl;
    str = sstream.str();

    if (!WriteFile(hout, str.c_str(), str.size(), &tlen, nullptr))
        return -1;


    if (!ReadFile(hin, inbuf, ilen, &tlen, nullptr))
        return -1;

    while(true);

    return 0;
}
```