### PR TITLE
Allow to specify environment variables in the .shim file (#4)

### DIFF
--- a/shim.cpp
+++ b/shim.cpp
@@ -121,32 +121,35 @@ ShimInfo GetShimInfo()
 
         std::wstring_view line(linebuf);
 
-        if ((line.size() < 7) || (line.substr(4, 3) != L" = "))
+        auto pos = line.find(L" = ");
+        if (pos == std::wstring_view::npos)
         {
             continue;
         }
 
-        if (line.substr(0, 4) == L"path")
+        std::wstring_view name = line.substr(0, pos);
+        std::wstring_view value = line.substr(pos + 3, line.size() - pos - 3 - (line.back() == L'\n' ? 1 : 0));
+
+        if (name == L"path")
         {
-            std::wstring_view line_substr = line.substr(7);
-            if (line_substr.find(L" ") != std::wstring_view::npos && line_substr.front() != L'"')
+            if (value.find(L" ") != std::wstring_view::npos && value.front() != L'"')
             {
                 path.emplace(L"\"");
                 auto& path_value = path.value();
-                path_value.append(line_substr.data(), line_substr.size() - (line.back() == L'\n' ? 1 : 0));
+                path_value.append(value);
                 path_value.push_back(L'"');
             }
             else
             {
-                path.emplace(line_substr.data(), line_substr.size() - (line.back() == L'\n' ? 1 : 0));
+                path.emplace(value);
             }
 
             continue;
         }
 
-        if (line.substr(0, 4) == L"args")
+        if (name == L"args")
         {
-            args.emplace(line.data() + 7, line.size() - 7 - (line.back() == L'\n' ? 1 : 0));
+            args.emplace(value);
             continue;
         }
     }


### PR DESCRIPTION
This PR allows to run the shimmed application with environment variables specified in the `.shim` file. Example:
```
path = C:\path\to\app.exe
MY_VAR = My Value
SCOOP_DIR = %LOCALAPPDATA%\scoop
```

The `.shim` file parser was extended to support arbitrary `name = value` pairs. If `name` is neither `path` nor `args`, it is treated as an environment variable to be set.

In addition, environment variables can refer to existing environment variables, such as `%LOCALAPPDATA%`. This resembles batch file syntax. If you don't like `%` characters, we can use any other delimiters like `<:/` `/:>` suggested in #7. In fact, the implementation of `NormalizeVariable` function is fairly generic and can serve as a base to implement #7 in future.