### PR TITLE
Set consoleAllocationPolicy=detached to shim manifest

### DIFF
--- a/shim.manifest
+++ b/shim.manifest
@@ -1,3 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <application>
+    <windowsSettings>
+      <consoleAllocationPolicy xmlns="http://schemas.microsoft.com/SMI/2024/WindowsSettings">detached</consoleAllocationPolicy>
+    </windowsSettings>
+  </application>
 </assembly>


### PR DESCRIPTION
As of Windows 11 24H2, Windows added support for CONSOLE subsystem applications to opt out of automatic console allocation ([learn.microsoft.com/en-us/windows/console/console-allocation-policy](https://learn.microsoft.com/en-us/windows/console/console-allocation-policy)).

```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
  <application>
    <windowsSettings>
      <consoleAllocationPolicy xmlns="http://schemas.microsoft.com/SMI/2024/WindowsSettings">detached</consoleAllocationPolicy>
    </windowsSettings>
  </application>
</assembly>
```

With that entry, the application will only get a console if it inherits one.

This would be useful for applications that have this value in their manifest, and it does not break existing behavior.
